### PR TITLE
Adds react and react-native as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,10 @@
     "istanbul": "^1.0.0-alpha"
   },
   "dependencies": {
-    "@cedarstudios/react-native-mapbox-gl": "git+https://github.com/cedarstudios/react-native-mapbox-gl.git",
-    "react": "^16.7.0",
-    "react-native": "^0.57.8"
+    "@cedarstudios/react-native-mapbox-gl": "git+https://github.com/cedarstudios/react-native-mapbox-gl.git"
+  },
+  "peerDependencies": {
+    "react": ">= 16.7.0",
+    "react-native": ">= 0.57.8"
   }
 }


### PR DESCRIPTION
React and React-Native should be used as peer dependency to avoiding `duplicate module name` error in the React-Native packager. 

## Changelog
- Removed React and React-Native from `dependencies` and added them to `peerDependencies`

## Test Plan
- Create a fresh React-Native project
- Install `cedarmaps-react-native-sdk` package
- Run the project

You should see that the React-Native packager is showing an error because there is a different version of React-Native in your project.
For more information check [this doc](
https://docs.npmjs.com/files/package.json#peerdependencies) out